### PR TITLE
Handle ekg-carbon exceptions gacefully

### DIFF
--- a/canteven-metrics.cabal
+++ b/canteven-metrics.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                canteven-metrics
-version:             0.1.1.0
+version:             0.1.1.1
 synopsis:            I canteven setup and use EKG metrics
 -- description:         
 homepage:            https://github.com/SumAll/haskell-canteven-metrics

--- a/canteven-metrics.cabal
+++ b/canteven-metrics.cabal
@@ -30,7 +30,7 @@ library
     bytestring,
     canteven-config,
     ekg,
-    ekg-carbon,
+    ekg-carbon >=1.0.4 && <1.1,
     ekg-core,
     http-client,
     text,


### PR DESCRIPTION
Version 1.0.4 of ekg-carbon exposes a new function: `forkCarbonRestart`, that can be used to handle exceptions generated during connection or sending data to Carbon.

If an exception occurs canteven-metrics will:

1. write a message to stderr
2. delay the current thread for 1 second
3. call the `restart` function

The `restart` function will try to connect and to periodically flush data to Carbon.

See also https://github.com/ocharles/ekg-carbon/issues/3